### PR TITLE
Wrong namespace for Exception class fix

### DIFF
--- a/Geolocation/GeolocationApi.php
+++ b/Geolocation/GeolocationApi.php
@@ -121,7 +121,7 @@ class GeolocationApi
     {
         if (true === is_null($this->em))
         {
-            throw new Exception("Cannot enable cache. EntityManager must be set via setEntityManager()");
+            throw new \Exception("Cannot enable cache. EntityManager must be set via setEntityManager()");
         }
         
         $this->cacheAvailable = true;


### PR DESCRIPTION
Before lack of backslash cause Fatal error: Class 'Google\GeolocationBundle\Geolocation\Exception'
