### PR TITLE
Changing @ORM\PreUpdate annotation case.

### DIFF
--- a/Entity/ApiLog.php
+++ b/Entity/ApiLog.php
@@ -46,7 +46,7 @@ class ApiLog
     }
 
     /**
-     * @ORM\preUpdate
+     * @ORM\PreUpdate
      */
     public function setUpdatedValue()
     {


### PR DESCRIPTION
Changing PreUpdate annotation to avoid case sensitive error on unix systems.
