### PR TITLE
Fixes typo on Doctrine lifecycle event (PreUpdate)

### DIFF
--- a/Entity/Location.php
+++ b/Entity/Location.php
@@ -62,7 +62,7 @@ class Location
     }
 
     /**
-     * @ORM\preUpdate
+     * @ORM\PreUpdate
      */
     public function setUpdatedValue()
     {


### PR DESCRIPTION
Avoids this error message when I use doctrine fixtures command:

```
[Doctrine\Common\Annotations\AnnotationException]                                                                                                                                       
[Semantical Error] The annotation "@Doctrine\ORM\Mapping\preUpdate" in method Google\GeolocationBundle\Entity\Location::setUpdatedValue() does not exist, or could not be auto-loaded. 
```
