### PR TITLE
Fix for Symfony 3.1 requiring quoting of scalar

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,10 +4,10 @@ parameters:
     google_geolocation.geolocation_api.daily_limit: 2500
     # Max lifetime of geocoding result (hours). Set to 0 to disable caching
     google_geolocation.geolocation_api.cache_lifetime: 24
-    
+
 services:
     google_geolocation.geolocation_api:
-        class:      %google_geolocation.geolocation_api.class%
+        class: "%google_geolocation.geolocation_api.class%"
         #calls:
         #    - [ setEntityManager, [ @doctrine.orm.entity_manager ] ]
         #    - [ setDailyLimit, [ %google_geolocation.geolocation_api.daily_limit% ] ]


### PR DESCRIPTION
Since Symfony 3.1, scalars are required to be wrapped in single or double quotes